### PR TITLE
修复int类型长度不足导致数据解析失败的bug以及前台数据绑定失败的问题

### DIFF
--- a/wowsCheaterViewer/ApiClient.cs
+++ b/wowsCheaterViewer/ApiClient.cs
@@ -116,32 +116,32 @@ namespace wowsCheaterViewer
             string url = address_official + "/api/accounts/search/autocomplete/" + Uri.EscapeDataString(playerName);
             return GetClientAsync(url).Result;
         }
-        public static string? GetPlayerInfo_official(int playerId)//通过玩家id获取官方的玩家信息
+        public static string? GetPlayerInfo_official(long playerId)//通过玩家id获取官方的玩家信息
         {
             string url = address_official + "/api/accounts/" + playerId;
             return GetClientAsync(url).Result;
         }
-        public static string? GetPalyersShipsInfo_official(int playerId, string battleType)//通过玩家id获取官方的玩家船信息
+        public static string? GetPalyersShipsInfo_official(long playerId, string battleType)//通过玩家id获取官方的玩家船信息
         {
             string url = address_official + "/api/accounts/" + playerId + "/ships/" + battleType.ToLower();
             return GetClientAsync(url).Result;
         }
-        public static string? GetPalyersClansInfo_official(int playerId)//通过玩家id获取官方的玩家军团信息
+        public static string? GetPalyersClansInfo_official(long playerId)//通过玩家id获取官方的玩家军团信息
         {
             string url = address_official + "/api/accounts/" + playerId + "/clans";
             return GetClientAsync(url).Result;
         }
-        public static string? GetPlayerInfo_yuyuko(int playerId)//通过玩家id获取yuyuko的玩家信息
+        public static string? GetPlayerInfo_yuyuko(long playerId)//通过玩家id获取yuyuko的玩家信息
         {
             string url = address_yuyukoWowsApi_域名3 + "/public/wows/account/user/info?server=cn&accountId=" + playerId;
             return GetClientAsync(url).Result;
         }
-        public static string? GetPlayerShipInfo_yuyuko(int playerId, int shipId)//通过玩家id和船id获取yuyuko(old)的玩家单船信息
+        public static string? GetPlayerShipInfo_yuyuko(long playerId, long shipId)//通过玩家id和船id获取yuyuko(old)的玩家单船信息
         {
             string url = address_yuyukoWowsApi_域名3 + "/public/wows/account/ship/info?accountId=" + playerId + "&server=cn&shipId=" + shipId;
             return GetClientAsync(url).Result;
         }
-        public static string? GetPlayerBanInfo_yuyuko(int playerId)//通过玩家id获取yuyuko的ban信息
+        public static string? GetPlayerBanInfo_yuyuko(long playerId)//通过玩家id获取yuyuko的ban信息
         {
             string url = address_yuyukoWowsApi_域名3 + "/public/wows/ban/cn/user";
             Dictionary<string, string> contantDictionary = new()
@@ -150,17 +150,17 @@ namespace wowsCheaterViewer
             };
             return PostClientAsync(url, JsonConvert.SerializeObject(contantDictionary), null).Result;
         }
-        public static string? GetShipInfo(int shipId)//通过船id获取yuyuko的船信息
+        public static string? GetShipInfo(long shipId)//通过船id获取yuyuko的船信息
         {
             string url = address_yuyukoWowsApi_域名3 + "/public/wows/encyclopedia/ship/info?shipId=" + shipId;
             return GetClientAsync(url).Result;
         }
-        public static string? GetPlayerShipRankSort(int playerId, int shipId)//通过玩家id和船id获取yuyuko的排行，顺便帮雨季收集玩家信息
+        public static string? GetPlayerShipRankSort(long playerId, long shipId)//通过玩家id和船id获取yuyuko的排行，顺便帮雨季收集玩家信息
         {
             string url = address_yuyuko战舰世界API平台接口处理与反向代理 + "/wows/rank/cn/sort/" + playerId + "/" + shipId;
             return GetClientAsync(url).Result;
         }
-        public static string? GetParsedPlayerInfo_yuyuko(int playerId, int shipId, string battleType, string uploadFilePath, string clanFilePath)//用官网返回的信息写入文件，让yuyuko解析
+        public static string? GetParsedPlayerInfo_yuyuko(long playerId, long shipId, string battleType, string uploadFilePath, string clanFilePath)//用官网返回的信息写入文件，让yuyuko解析
         {
             string url = address_yuyuko战舰世界API平台接口处理与反向代理 + "/process/wows/user/info/cn/upload/vortex/data/" + battleType.ToUpper() + "/battle/" + playerId + "/query/" + shipId;
             return PostClientAsync(url, null, new Dictionary<string, string> { { "files", uploadFilePath }, { "clan", clanFilePath } }).Result;

--- a/wowsCheaterViewer/Config.cs
+++ b/wowsCheaterViewer/Config.cs
@@ -120,7 +120,7 @@ namespace wowsCheaterViewer
             Update();
         }
 
-        public void AddShipInfo(int shipId, ShipInfo ShipInfo)//新增船信息
+        public void AddShipInfo(long shipId, ShipInfo ShipInfo)//新增船信息
         {
             if (!this.ShipInfo.ContainsKey(shipId.ToString()))
                 this.ShipInfo[shipId.ToString()] = ShipInfo;

--- a/wowsCheaterViewer/MainWindow.xaml
+++ b/wowsCheaterViewer/MainWindow.xaml
@@ -72,14 +72,14 @@
                                         <ColumnDefinition Width="10"/>
                                         <ColumnDefinition/>
                                     </Grid.ColumnDefinitions>
-                                    <Border Grid.Column="0" Background="{Binding playerPrColor}" />
+                                    <Border Grid.Column="0" Background="{Binding PlayerPrColor}" />
                                     <TextBlock Grid.Column="1">
                                     <Run />
-                                    <Run Text="{Binding clanTag}" Foreground="{Binding clanColor}"/>
-                                    <Run Text="{Binding name}"/>
+                                    <Run Text="{Binding ClanTag}" Foreground="{Binding ClanColor}"/>
+                                    <Run Text="{Binding Name}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding shipLevel_roman}"/>
-                                    <Run Text="{Binding shipName}"/>
+                                    <Run Text="{Binding ShipLevel_roman}"/>
+                                    <Run Text="{Binding ShipName}"/>
                                     </TextBlock>
                                 </Grid>
                             </DataTemplate>
@@ -90,9 +90,9 @@
                             <DataTemplate>
                                 <TextBlock>
                                     <Run />
-                                    <Run Text="{Binding winRate_ship}"/>
+                                    <Run Text="{Binding WinRate_ship}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding battleCount_ship}"/>
+                                    <Run Text="{Binding BattleCount_ship}"/>
                                 </TextBlock>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -102,9 +102,9 @@
                             <DataTemplate>
                                 <TextBlock>
                                     <Run />
-                                    <Run Text="{Binding winRate_pvp}"/>
+                                    <Run Text="{Binding WinRate_pvp}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding battleCount_pvp}"/>
+                                    <Run Text="{Binding BattleCount_pvp}"/>
                                 </TextBlock>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -114,9 +114,9 @@
                             <DataTemplate>
                                 <TextBlock>
                                     <Run />
-                                    <Run Text="{Binding winRate_rank}"/>
+                                    <Run Text="{Binding WinRate_rank}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding battleCount_rank}"/>
+                                    <Run Text="{Binding BattleCount_rank}"/>
                                 </TextBlock>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -124,9 +124,9 @@
                     <DataGridTemplateColumn Header="封禁匹配" Width="60">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Background="{Binding banColor}" Text="{Binding banMatch}">
+                                <TextBlock Background="{Binding BanColor}" Text="{Binding BanMatch}">
                                     <TextBlock.ToolTip>
-                                        <TextBlock Text="{Binding banMatch_fullStr}"/>
+                                        <TextBlock Text="{Binding BanMatch_fullStr}"/>
                                     </TextBlock.ToolTip>
                                 </TextBlock>
                             </DataTemplate>
@@ -135,9 +135,9 @@
                     <DataGridTemplateColumn Header="标记" Width="*">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBox Text="{Binding markMessage,Mode=TwoWay,UpdateSourceTrigger=LostFocus}" LostFocus="MarkMessageChangedEvent">
+                                <TextBox Text="{Binding MarkMessage,Mode=TwoWay,UpdateSourceTrigger=LostFocus}" LostFocus="MarkMessageChangedEvent">
                                     <TextBox.ToolTip>
-                                        <TextBlock Text="{Binding lastMarkMessage}"/>
+                                        <TextBlock Text="{Binding LastMarkMessage}"/>
                                     </TextBox.ToolTip>
                                 </TextBox>
                             </DataTemplate>
@@ -157,14 +157,14 @@
                                         <ColumnDefinition Width="10"/>
                                         <ColumnDefinition/>
                                     </Grid.ColumnDefinitions>
-                                    <Border Grid.Column="0" Background="{Binding playerPrColor}" />
+                                    <Border Grid.Column="0" Background="{Binding PlayerPrColor}" />
                                     <TextBlock Grid.Column="1">
                                     <Run />
-                                    <Run Text="{Binding clanTag}" Foreground="{Binding clanColor}"/>
-                                    <Run Text="{Binding name}"/>
+                                    <Run Text="{Binding ClanTag}" Foreground="{Binding ClanColor}"/>
+                                    <Run Text="{Binding Name}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding shipLevel_roman}"/>
-                                    <Run Text="{Binding shipName}"/>
+                                    <Run Text="{Binding ShipLevel_roman}"/>
+                                    <Run Text="{Binding ShipName}"/>
                                     </TextBlock>
                                 </Grid>
                             </DataTemplate>
@@ -175,9 +175,9 @@
                             <DataTemplate>
                                 <TextBlock>
                                     <Run />
-                                    <Run Text="{Binding winRate_ship}"/>
+                                    <Run Text="{Binding WinRate_ship}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding battleCount_ship}"/>
+                                    <Run Text="{Binding BattleCount_ship}"/>
                                 </TextBlock>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -187,9 +187,9 @@
                             <DataTemplate>
                                 <TextBlock>
                                     <Run />
-                                    <Run Text="{Binding winRate_pvp}"/>
+                                    <Run Text="{Binding WinRate_pvp}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding battleCount_pvp}"/>
+                                    <Run Text="{Binding BattleCount_pvp}"/>
                                 </TextBlock>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -199,9 +199,9 @@
                             <DataTemplate>
                                 <TextBlock>
                                     <Run />
-                                    <Run Text="{Binding winRate_rank}"/>
+                                    <Run Text="{Binding WinRate_rank}"/>
                                     <Run Text="&#13;"/>
-                                    <Run Text="{Binding battleCount_rank}"/>
+                                    <Run Text="{Binding BattleCount_rank}"/>
                                 </TextBlock>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -209,9 +209,9 @@
                     <DataGridTemplateColumn Header="封禁匹配" Width="60">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Background="{Binding banColor}" Text="{Binding banMatch}">
+                                <TextBlock Background="{Binding BanColor}" Text="{Binding BanMatch}">
                                     <TextBlock.ToolTip>
-                                        <TextBlock Text="{Binding banMatch_fullStr}"/>
+                                        <TextBlock Text="{Binding BanMatch_fullStr}"/>
                                     </TextBlock.ToolTip>
                                 </TextBlock>
                             </DataTemplate>
@@ -220,9 +220,9 @@
                     <DataGridTemplateColumn Header="标记" Width="*">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBox Text="{Binding markMessage,Mode=TwoWay,UpdateSourceTrigger=LostFocus}" LostFocus="MarkMessageChangedEvent">
+                                <TextBox Text="{Binding MarkMessage,Mode=TwoWay,UpdateSourceTrigger=LostFocus}" LostFocus="MarkMessageChangedEvent">
                                     <TextBox.ToolTip>
-                                        <TextBlock Text="{Binding lastMarkMessage}"/>
+                                        <TextBlock Text="{Binding LastMarkMessage}"/>
                                     </TextBox.ToolTip>
                                 </TextBox>
                             </DataTemplate>
@@ -230,7 +230,6 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
-
         </Grid>
     </Grid>
 </Window>

--- a/wowsCheaterViewer/PlayerInfo.cs
+++ b/wowsCheaterViewer/PlayerInfo.cs
@@ -11,13 +11,13 @@ namespace wowsCheaterViewer
     public class PlayerInfo : PlayerGameInfoInRep
     {
         private const string errorMessage = "error";
-        public int PlayerId { get; set; } = 0;//默认值给0，方便提供给yuyuko
+        public long PlayerId { get; set; } = 0;//默认值给0，方便提供给yuyuko
         public string? PlayerPrColor { get; set; } = "Gray";//默认灰色（隐藏战绩或读取失败）
         public bool IsHidden { get; set; }
 
 
         public string? ClanTag { get; set; }
-        public int ClanId { get; set; } = 0;//默认值给0，方便提供给yuyuko
+        public long ClanId { get; set; } = 0;//默认值给0，方便提供给yuyuko
         public string? ClanColor { get; set; }
 
 
@@ -100,7 +100,7 @@ namespace wowsCheaterViewer
                 JObject result_getPlayerId = JObject.Parse(ApiClient.GetPlayerId(Name)!);
                 if (JArray.FromObject(result_getPlayerId["data"]!).Count == 0)
                     throw new Exception("未能获取玩家id，可能已改名。");
-                PlayerId = (int)result_getPlayerId["data"]?[0]?["spa_id"]!;
+                PlayerId = (long)result_getPlayerId["data"]?[0]?["spa_id"]!;
                 IsHidden = Convert.ToBoolean(result_getPlayerId["data"]?[0]?["hidden"]);
                 clanEmptyFilePath = WriteFile(PlayerId + "_clan.txt", "");//写入空文件用于上传军团信息
                 tempFiles.Add(clanEmptyFilePath);
@@ -173,7 +173,7 @@ namespace wowsCheaterViewer
                 JObject PlayersClanInfoJo = JObject.Parse(PlayersClanInfoStr!);
                 if(!string.IsNullOrEmpty(PlayersClanInfoJo["data"]?["clan_id"]?.ToString()))
                 {
-                    ClanId = (int)PlayersClanInfoJo["data"]?["clan_id"]!;
+                    ClanId = (long)PlayersClanInfoJo["data"]?["clan_id"]!;
                     ClanTag = "[" + PlayersClanInfoJo["data"]?["clan"]?["tag"]?.ToString() + "]";
                     ClanColor = "#" + Convert.ToInt32(PlayersClanInfoJo["data"]?["clan"]?["color"]).ToString("X");
                 }
@@ -336,11 +336,11 @@ namespace wowsCheaterViewer
     public class YuyukoPlayerInfo//为yuyuko机器人收集信息用的子类
     {
         public string Server { get; set; } = "cn";
-        public int AccountId { get; set; }
+        public long AccountId { get; set; }
         public string? UserName { get; set; }
-        public int ShipId { get; set; }
+        public long ShipId { get; set; }
         public bool Hidden { get; set; }
-        public int ClanId { get; set; }
+        public long ClanId { get; set; }
         public string? Tag { get; set; }
         public int Relation { get; set; }
     }
@@ -348,9 +348,9 @@ namespace wowsCheaterViewer
     public class PlayerGameInfoInRep//从rep文件里获取的玩家信息
     {
         private string? _name;
-        public int ShipId { get; set; }
+        public long ShipId { get; set; }
         public int Relation { get; set; }
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Name
         {
             get => _name!;


### PR DESCRIPTION
1. 代码中Id原数据类型为int，长度不足导致报错，修改为long.
2. 代码将属性命名修改为大写后前台绑定未同步修改，导致数据绑定失败，现已修改